### PR TITLE
R.3.2 - Add AI Chat model upload to admin panel

### DIFF
--- a/Tulip/Models/Chat/ChatSettingsViewModel.cs
+++ b/Tulip/Models/Chat/ChatSettingsViewModel.cs
@@ -1,0 +1,9 @@
+namespace Tulip.Models
+{
+    public class ChatSettingsViewModel
+    {
+        public bool AIIsEnabled { get; set; }
+
+        public string AIModelFileName { get; set; }
+    }
+}

--- a/Tulip/Program.cs
+++ b/Tulip/Program.cs
@@ -4,6 +4,7 @@ using Tulip.Services.Implementations;
 using Tulip.Services.Interfaces;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Http.Features;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -13,6 +14,15 @@ builder.Logging.AddConsole();
 /* Add Configuration Providers */
 builder.Configuration.AddInMemoryCollection(new Dictionary<string, string>{
     { "AIChatModelPath", "" }
+});
+
+/* Increase max upload size for AI model upload */
+const long maxUploadSize = 1024L * 1024L * 1024L * 5L; // 5GB max upload limit
+builder.Services.Configure<FormOptions>(options => {
+    options.MultipartBodyLengthLimit = maxUploadSize; 
+});
+builder.WebHost.ConfigureKestrel(serverOptions => {
+    serverOptions.Limits.MaxRequestBodySize = maxUploadSize;
 });
 
 /* Add Services */
@@ -35,7 +45,6 @@ builder.Services.AddScoped<ISAPBuilder, SAPBuilder>();
 builder.Services.AddScoped<ITasksServices, TasksService>();
 
 builder.Services.AddSingleton<IAIChat, LLamaChat>();
-// builder.Services.AddScoped<IAIChatSession, LLamaChatSession>();
 
 builder.Services.AddScoped(sp => new HttpClient { 
     BaseAddress = new Uri(builder.Configuration.GetValue<string>("APIKey"))

--- a/Tulip/Services/Interfaces/AIChat/IAIChat.cs
+++ b/Tulip/Services/Interfaces/AIChat/IAIChat.cs
@@ -6,7 +6,7 @@ namespace Tulip.Services.Interfaces
     {
         public bool IsEnabled();
         public void Disable();
-        public void Enable(string modelPath);
+        public void Enable();
         public IAIChatSession GetChatSession(ApplicationUser user);
     }
 }

--- a/Tulip/Tulip.csproj
+++ b/Tulip/Tulip.csproj
@@ -28,10 +28,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content PublishState="Included" Include="Hubs/llama-2-7b-chat.gguf" CopyToOutputDirectory="PreserveNewest" />
-  </ItemGroup>
-
-  <ItemGroup>
     <None Include="wwwroot\assets\js\config.js" />
     <None Include="wwwroot\assets\js\dashboards-analytics.js" />
     <None Include="wwwroot\assets\js\extended-ui-perfect-scrollbar.js" />

--- a/Tulip/Views/Chat/Settings.cshtml
+++ b/Tulip/Views/Chat/Settings.cshtml
@@ -1,0 +1,55 @@
+@model Tulip.Models.ChatSettingsViewModel;
+
+<div class="container p-5">
+    <div class="row">
+        <div class="col-8">
+            <div class="card">
+                <h5 class="card-header">Chat Settings</h5>
+                <div class="card-body">
+                    <form enctype="multipart/form-data" asp-controller="Chat" asp-action="SaveSettings" >
+                        <div class="form-group row pb-2">
+                            <div class="col-5">Enable AI Chat</div>
+                            <div class="col-7">
+                                <div class="form-check">
+                                    <label class="form-check-label d-none" for="aiIsEnabled-switch">AI Chat System</label>
+                                    <input asp-for="AIIsEnabled" class="form-check-input" id="aiIsEnabled-switch" />
+                                </div>
+                            </div>
+                        </div>
+                        <div class="form-group row pb-2">
+                            <label class="col-5" for="aiModelFile">AI Chat Model</label>
+                            <div class="col-7">
+                                @if (Model.AIModelFileName != "")
+                                {
+                                    <p>@Model.AIModelFileName</p>
+                                }
+                                else 
+                                {
+                                    <p>No model has been uploaded yet</p>
+                                }
+                            </div>
+                        </div>
+                        <div class="form-group row pb-4">
+                            <label class="col-5" for="aiModelFile">Upload New AI Chat Model</label>
+                            <div class="col-7">
+                                <input class="form-control" 
+                                    type="file" 
+                                    name="modelUpload"
+                                    id="aiModelFile" 
+                                    accept=".gguf" />
+                            </div>
+                            <p class="card-text pt-4">
+                                Note: Uploading a new AI Chat model may take a few minutes.
+                            </p>
+                        </div>
+                        <div class="form-group row justify-content-center">
+                            <div class="text-center">
+                                <button type="submit" value="Save" class="btn btn-primary">Save</button>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/Tulip/Views/Shared/_AsideView.cshtml
+++ b/Tulip/Views/Shared/_AsideView.cshtml
@@ -141,6 +141,11 @@
                                 </li>
                             </ul>
                         </li>
+                        <li class="menu-item">
+                            <a asp-controller="Chat" asp-action="Settings" class="menu-link">
+                                <div data-i18n="Basic">Chat</div>
+                            </a>
+                        </li>
                     }
 
                     // if user is admin, then we just need the reset password

--- a/Tulip/wwwroot/js/chat/compose.js
+++ b/Tulip/wwwroot/js/chat/compose.js
@@ -1,5 +1,5 @@
 import { Connection } from "./Connection.js";
 import { getEditor } from "./Editor.js";
 
-const connection = await Connection.getInstance();
+const connection = new Connection();
 const editor = getEditor(connection);


### PR DESCRIPTION
This PR adds a new chat settings section to the admin panel. The only settings available pertain to the AI chat system. From the chat settings, an admin can upload the AI chat model to use along with enabling or disabling the AI chat system.

This PR closes #60. While there is still work to be done on the AI Chat system, the basic functionality is in place and it's ready to be used.

![Screenshot 2024-04-23 at 12 31 36 PM](https://github.com/kclapper/tulip/assets/35474281/cc6bd062-c444-4cd2-b801-cb9d0e8f39ee)
