### PR TITLE
R.3.1 - Order user chats by most recent and better chat default views

### DIFF
--- a/Tulip/Models/Chat/ChatViewModel.cs
+++ b/Tulip/Models/Chat/ChatViewModel.cs
@@ -1,14 +1,61 @@
 using System.ComponentModel.DataAnnotations;
+using Microsoft.DotNet.Scaffolding.Shared.Messaging;
 
 namespace Tulip.Models
 {
     public class ChatViewModel
     {
         [Required] 
-        public IDictionary<ApplicationUser, MessageHistory> Chats { get; set; }
+        public ChatList Chats { get; set; }
 
         public MessageHistory CurrentChat { get; set; }
         public bool AIIsEnabled { get; set;}
+    }
+
+    public class ChatList : IEnumerable<KeyValuePair<ApplicationUser, MessageHistory>> {
+        private IDictionary<ApplicationUser, MessageHistory> chatsByUser = new Dictionary<ApplicationUser, MessageHistory>();
+
+        public bool ContainsUser(ApplicationUser user)
+        {
+            return chatsByUser.ContainsKey(user);
+        }
+
+        public MessageHistory GetMessageHistory(ApplicationUser user)
+        {
+            MessageHistory history;
+            chatsByUser.TryGetValue(user, out history);
+            return history;
+        }
+
+        public void Add(ApplicationUser user, MessageHistory history)
+        {
+            chatsByUser.Add(user, history);
+        }
+
+        public MessageHistory MostRecentChat()
+        {
+            var chatList = GetEnumerator();
+            chatList.MoveNext();
+            return chatList.Current.Value;
+        }
+
+        public int Count()
+        {
+            return chatsByUser.Count;
+        }
+
+        public IEnumerator<KeyValuePair<ApplicationUser, MessageHistory>> GetEnumerator()
+        {
+            List<KeyValuePair<ApplicationUser, MessageHistory>> chatList = chatsByUser.ToList();
+            chatList.Sort((first, second) => second.Value.Messages.First().Timestamp.CompareTo(first.Value.Messages.First().Timestamp));
+            return chatList.GetEnumerator();
+        }
+
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            IEnumerator<KeyValuePair<ApplicationUser, MessageHistory>> enumerator = GetEnumerator();
+            return enumerator;
+        }
     }
 
     public class MessageHistory

--- a/Tulip/Views/Chat/_ChatLayout.cshtml
+++ b/Tulip/Views/Chat/_ChatLayout.cshtml
@@ -62,30 +62,25 @@
             <div id="chatList" class="ps-4 pe-3">
                 <div class="card">
                     <ul class="list-group list-group-flush">
-                        @if (Model.CurrentChat != null)
-                        {
-                            ApplicationUser currentChatUser = Model.CurrentChat.OtherUser;
-                            <li class="list-group-item shadow-sm active">
-                                <div class="row no-gutters align-items-center">
-                                    <div class="col-4">
-                                        <span class="badge bg-label-info">
-                                            <i class="bx bx-medal text-primary bx-sm"></i>
-                                        </span>
-                                    </div>
-                                    <div class="col-8 text-center">
-                                            <a class="text-white" asp-controller="Chat" asp-action="Message" asp-route-userId="@currentChatUser.Id">
-                                                @currentChatUser.UserName
-                                            </a>
-                                    </div>
-                                </div>
-                            </li>
-                        }
                         @foreach (var chat in Model.Chats) 
                         {
                             ApplicationUser otherUser = chat.Key;
                             @if (Model.CurrentChat != null && otherUser.Equals(Model.CurrentChat.OtherUser))
                             {
-                                continue;
+                                <li class="list-group-item shadow-sm active">
+                                    <div class="row no-gutters align-items-center">
+                                        <div class="col-4">
+                                            <span class="badge bg-label-info">
+                                                <i class="bx bx-medal text-primary bx-sm"></i>
+                                            </span>
+                                        </div>
+                                        <div class="col-8 text-center">
+                                                <a class="text-white" asp-controller="Chat" asp-action="Message" asp-route-userId="@otherUser.Id">
+                                                    @otherUser.UserName
+                                                </a>
+                                        </div>
+                                    </div>
+                                </li>
                             }
                             else 
                             {


### PR DESCRIPTION
Closes #70 #69 

Orders user chats with the most recent at the top of the sidebar.

Clicking on the chat panel will either open your most recent chat, or the compose menu if you've never chatted with anyone.